### PR TITLE
unload bug fix

### DIFF
--- a/controllers/playerController.js
+++ b/controllers/playerController.js
@@ -215,9 +215,9 @@ export function renderPlayer(req, res) {
           }
           startPlayer();
 
-          window.addEventListener('unload', function() {
-            navigator.sendBeacon('/goodbye?url=' + encodeURIComponent(magnet));
-          });
+      window.addEventListener('pagehide', function() {
+  navigator.sendBeacon('/goodbye?url=' + encodeURIComponent(magnet));
+});
         </script>
       </body>
     </html>


### PR DESCRIPTION
This pull request makes a minor update to the `renderPlayer` function in `playerController.js`, improving the reliability of sending a beacon when the user leaves the page.

- Changed the event listener from `unload` to `pagehide` for sending a beacon when the user navigates away from the page, ensuring better compatibility and reliability across browsers.