### PR TITLE
pip removed

### DIFF
--- a/libs/player.js
+++ b/libs/player.js
@@ -507,6 +507,18 @@ class VideoPlayerController {
       if (!this.playerInitialized) {
         this.plyrInstance = new Plyr(this.ui.elements.video, {
           captions: { active: true, update: true, language: "en" },
+          controls: [
+            "play",
+            "progress",
+            "current-time",
+            "mute",
+            "volume",
+            "captions",
+            "settings",
+            "fullscreen",
+            // 'pip' is omitted to disable Picture-in-Picture
+          ],
+          pip: false, // Explicitly disable PiP API
         });
         this.playerInitialized = true;
       }


### PR DESCRIPTION
This pull request makes a targeted change to the video player configuration by updating the controls and explicitly disabling the Picture-in-Picture (PiP) feature.

Video player controls update:

* In `libs/player.js`, the `VideoPlayerController` class now specifies a custom set of controls for the Plyr instance, omitting 'pip' to disable Picture-in-Picture, and sets the `pip` option to `false` to ensure the PiP API is disabled.