### PR TITLE
patch

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,14 +3,11 @@ import cors from "cors";
 import compression from "compression";
 import path from "path";
 import { fileURLToPath } from "url";
-import fs from "fs";
-import { promisify } from "util";
 
 import videoRoutes from "./routes/videoRoutes.js";
 import statusRoutes from "./routes/statusRoutes.js";
 import subtitleRoutes from "./routes/subtitleRoutes.js";
 import playerRoutes from "./routes/playerRoutes.js";
-import { destroyTorrent } from "./services/torrentService.js";
 
 const app = express();
 app.use(cors());
@@ -30,39 +27,6 @@ app.use(playerRoutes);
 app.use(videoRoutes);
 app.use(statusRoutes);
 app.use(subtitleRoutes);
-
-app.get("/sysinfo", (req, res) => {
-  const mem = process.memoryUsage();
-  const cpu = process.cpuUsage();
-  res.render("sysinfo", {
-    memory: mem,
-    cpu: cpu,
-    uptime: process.uptime(),
-    pid: process.pid,
-    platform: process.platform,
-    nodeVersion: process.version,
-  });
-});
-
-const rm = promisify(fs.rm);
-
-// Goodbye route
-app.get("/goodbye", async (req, res) => {
-  const magnet = req.query.url;
-  // destroyTorrent should return the path to the downloaded folder or file
-  const torrentPath = destroyTorrent(magnet);
-  if (torrentPath) {
-    try {
-      await rm(torrentPath, { recursive: true, force: true });
-      res.status(200).send("Torrent destroyed and files deleted");
-    } catch (err) {
-      console.error("Failed to delete files:", err);
-      res.status(500).send("Torrent destroyed, but failed to delete files");
-    }
-  } else {
-    res.status(200).send("Torrent destroyed (no files to delete)");
-  }
-});
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/controllers/statusController.js
+++ b/controllers/statusController.js
@@ -37,3 +37,15 @@ export function getStatus(req, res) {
     error: t.error ? t.error.message : undefined,
   });
 }
+export function getSysInfo(req, res) {
+  const mem = process.memoryUsage();
+  const cpu = process.cpuUsage();
+  res.render("sysinfo", {
+    memory: mem,
+    cpu: cpu,
+    uptime: process.uptime(),
+    pid: process.pid,
+    platform: process.platform,
+    nodeVersion: process.version,
+  });
+}

--- a/controllers/videoController.js
+++ b/controllers/videoController.js
@@ -1,5 +1,6 @@
 // Video streaming controller
-import { getOrAddTorrent } from "../services/torrentService.js";
+import { getOrAddTorrent, destroyTorrent } from "../services/torrentService.js";
+import { rm } from "fs/promises";
 
 const MIN_READY_BYTES = 256 * 1024; // 256KB for ultra-fast start
 const PRIORITY_PIECES = 20; // Download first 20 pieces with priority
@@ -116,4 +117,21 @@ export function streamVideo(req, res) {
     stream.destroy();
   });
   stream.pipe(res);
+}
+
+export async function goodbye(req, res) {
+  const magnet = req.query.url;
+  // Always destroy the torrent first
+  const torrentPath = destroyTorrent(magnet);
+  if (torrentPath) {
+    try {
+      await rm(torrentPath, { recursive: true, force: true });
+      res.status(200).send("Torrent destroyed and files deleted");
+    } catch (err) {
+      console.error("Failed to delete files:", err);
+      res.status(500).send("Torrent destroyed, but failed to delete files");
+    }
+  } else {
+    res.status(200).send("Torrent destroyed (no files to delete)");
+  }
 }

--- a/routes/statusRoutes.js
+++ b/routes/statusRoutes.js
@@ -1,7 +1,8 @@
 import express from "express";
-import { getStatus } from "../controllers/statusController.js";
+import { getStatus, getSysInfo } from "../controllers/statusController.js";
 const router = express.Router();
 
 router.get("/status", getStatus);
+router.get("/sysinfo", getSysInfo);
 
 export default router;

--- a/routes/videoRoutes.js
+++ b/routes/videoRoutes.js
@@ -1,7 +1,9 @@
 import express from "express";
-import { streamVideo } from "../controllers/videoController.js";
+import { goodbye, streamVideo } from "../controllers/videoController.js";
+
 const router = express.Router();
 
 router.get("/video", streamVideo);
+router.get("/goodbye", goodbye);
 
 export default router;


### PR DESCRIPTION
This pull request refactors the handling of the `/sysinfo` and `/goodbye` routes by moving their logic out of `app.js` and into dedicated controller functions. This improves the modularity and maintainability of the codebase by keeping route logic within appropriate controllers and route files.

**Route and Controller Refactoring:**

* Moved the `/sysinfo` route logic from `app.js` to a new `getSysInfo` controller in `statusController.js`, and registered the route in `statusRoutes.js`. (`[[1]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL34-L66)`, `[[2]](diffhunk://#diff-4bc4fb75dd248108380ea3efd51ff3f52b75e2a8800dbd38d3f1e9d15d5abe9bR40-R51)`, `[[3]](diffhunk://#diff-9eda1268b4df2a2c37fa041b11d11f6b7e30acc1bd4bb89e6c5dd3e77c695e8aL2-R6)`)
* Moved the `/goodbye` route logic from `app.js` to a new `goodbye` controller in `videoController.js`, and registered the route in `videoRoutes.js`. (`[[1]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL34-L66)`, `[[2]](diffhunk://#diff-43ae33e1060ff009e44ab1ee49915cfe6761d36b4cd647679625cfd4a6f3944cR121-R137)`, `[[3]](diffhunk://#diff-1bcd54165062b466e24353485bf505c65a1a51973128a674bf854303eef6e5d0L2-R7)`)

**Dependency and Import Cleanup:**

* Removed unused imports (`fs`, `promisify`, and `destroyTorrent`) from `app.js`, and updated imports in controllers to use the correct modules. (`[[1]](diffhunk://#diff-e07d531ac040ce3f40e0ce632ac2a059d7cd60f20e61f78268ac3be015b3b28fL6-L13)`, `[[2]](diffhunk://#diff-43ae33e1060ff009e44ab1ee49915cfe6761d36b4cd647679625cfd4a6f3944cL2-R3)`)